### PR TITLE
Modernize code for C++17

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+# Configuration file for EditorConfig
+# More information is available under https://editorconfig.org/
+
+# Ignore any other files further up in the file system
+root = true
+
+# Configuration for all files
+[*]
+# Enforce Unix style line endings (\n only)
+end_of_line = lf
+# Always end files with a blank line
+insert_final_newline = true
+# Force space characters for indentation
+indent_style = space
+# Always indent by 4 characters
+indent_size = 4
+# Remove whitespace characters at the end of line
+trim_trailing_whitespace = true
+# Set default charset to UTF-8
+charset = utf-8

--- a/README.md
+++ b/README.md
@@ -14,23 +14,23 @@ Unit tests are written with the [Catch2](https://github.com/catchorg/Catch2) tes
 
 struct DummyMessage : public pub::Message
 {
-	int important_value = 0;
+    int important_value = 0;
 };
 
 int main()
 {
-	auto bus = pub::MessageBus{};
-	auto msg = DummyMessage{};
-	msg.important_value = 100;
+    auto bus = pub::MessageBus{};
+    auto msg = DummyMessage{};
+    msg.important_value = 100;
 
-	bus.subscribe<DummyMessage>(
-		[](DummyMessage msg)
-		{
-			std::cout << "Important value: " << msg.important_value << "\n";
-		}
-	);
+    bus.subscribe<DummyMessage>(
+        [](DummyMessage msg)
+        {
+            std::cout << "Important value: " << msg.important_value << "\n";
+        }
+    );
 
-	bus.publish(msg);
+    bus.publish(msg);
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Unit tests are written with the [Catch2](https://github.com/catchorg/Catch2) test framework.
 
+**Note:** PubBus requires C++17
+
 ## Example
 
 ```c++
@@ -17,8 +19,8 @@ struct DummyMessage : public pub::Message
 
 int main()
 {
-	pub::MessageBus bus;
-	DummyMessage msg;
+	auto bus = pub::MessageBus{};
+	auto msg = DummyMessage{};
 	msg.important_value = 100;
 
 	bus.subscribe<DummyMessage>(

--- a/build/PubBus.vcxproj
+++ b/build/PubBus.vcxproj
@@ -137,6 +137,7 @@
     <ClInclude Include="..\include\PubBus\SubscriberHandle.hpp" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="..\.editorconfig" />
     <None Include="..\.gitattributes" />
     <None Include="..\.gitignore" />
     <None Include="..\LICENSE.md" />

--- a/build/PubBus.vcxproj
+++ b/build/PubBus.vcxproj
@@ -136,6 +136,12 @@
     <ClInclude Include="..\include\PubBus\PubBus.hpp" />
     <ClInclude Include="..\include\PubBus\SubscriberHandle.hpp" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="..\.gitattributes" />
+    <None Include="..\.gitignore" />
+    <None Include="..\LICENSE.md" />
+    <None Include="..\README.md" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/build/PubBus.vcxproj.filters
+++ b/build/PubBus.vcxproj.filters
@@ -46,5 +46,8 @@
     <None Include="..\README.md">
       <Filter>Documentation</Filter>
     </None>
+    <None Include="..\.editorconfig">
+      <Filter>Documentation</Filter>
+    </None>
   </ItemGroup>
 </Project>

--- a/build/PubBus.vcxproj.filters
+++ b/build/PubBus.vcxproj.filters
@@ -9,6 +9,9 @@
       <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
       <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
     </Filter>
+    <Filter Include="Documentation">
+      <UniqueIdentifier>{a4e826d9-367c-492b-b018-f4556a020201}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\include\PubBus\Message.hpp">
@@ -29,5 +32,19 @@
     <ClInclude Include="..\include\PubBus\PubBus.hpp">
       <Filter>Headerfiles</Filter>
     </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\.gitattributes">
+      <Filter>Documentation</Filter>
+    </None>
+    <None Include="..\.gitignore">
+      <Filter>Documentation</Filter>
+    </None>
+    <None Include="..\LICENSE.md">
+      <Filter>Documentation</Filter>
+    </None>
+    <None Include="..\README.md">
+      <Filter>Documentation</Filter>
+    </None>
   </ItemGroup>
 </Project>

--- a/build/Simple.vcxproj
+++ b/build/Simple.vcxproj
@@ -99,6 +99,7 @@
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)..\include</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -124,6 +125,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)..\include</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>

--- a/build/Test.vcxproj
+++ b/build/Test.vcxproj
@@ -103,6 +103,7 @@
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)..\include</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -128,6 +129,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)..\include</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>

--- a/examples/Simple/Simple.cpp
+++ b/examples/Simple/Simple.cpp
@@ -8,14 +8,14 @@ struct DummyMessage : public pub::Message
 
 int main()
 {
-	pub::MessageBus bus;
-	DummyMessage msg;
+    auto bus = pub::MessageBus{};
+    auto msg = DummyMessage{};
 	msg.important_value = 100;
 
 	bus.subscribe<DummyMessage>(
 		[](DummyMessage msg)
 		{
-			std::cout << "Important value: " << msg.important_value << std::endl;
+			std::cout << "Important value: " << msg.important_value << "\n";
 		}
 	);
 

--- a/examples/Simple/Simple.cpp
+++ b/examples/Simple/Simple.cpp
@@ -3,21 +3,21 @@
 
 struct DummyMessage : public pub::Message
 {
-	int important_value = 0;
+    int important_value = 0;
 };
 
 int main()
 {
     auto bus = pub::MessageBus{};
     auto msg = DummyMessage{};
-	msg.important_value = 100;
+    msg.important_value = 100;
 
-	bus.subscribe<DummyMessage>(
-		[](DummyMessage msg)
-		{
-			std::cout << "Important value: " << msg.important_value << "\n";
-		}
-	);
+    bus.subscribe<DummyMessage>(
+        [](DummyMessage msg)
+        {
+            std::cout << "Important value: " << msg.important_value << "\n";
+        }
+    );
 
-	bus.publish(msg);
+    bus.publish(msg);
 }

--- a/include/PubBus/Message.hpp
+++ b/include/PubBus/Message.hpp
@@ -5,19 +5,19 @@
 
 namespace pub
 {
-	class Message
-	{
-	public:
-		using Id = std::type_index;
+    class Message
+    {
+    public:
+        using Id = std::type_index;
 
-	public:
-		template<typename T>
-		static Id id();
-	};
+    public:
+        template<typename T>
+        static Id id();
+    };
 
-	template<typename T>
-	Message::Id Message::id()
-	{
+    template<typename T>
+    Message::Id Message::id()
+    {
         return std::type_index{ typeid(T) };
-	}
+    }
 }

--- a/include/PubBus/Message.hpp
+++ b/include/PubBus/Message.hpp
@@ -18,6 +18,6 @@ namespace pub
 	template<typename T>
 	Message::Id Message::id()
 	{
-		return std::type_index(typeid(T));
+        return std::type_index{ typeid(T) };
 	}
 }

--- a/include/PubBus/MessageBus.hpp
+++ b/include/PubBus/MessageBus.hpp
@@ -28,8 +28,8 @@ namespace pub
 	SubscriberHandle MessageBus::subscribe(std::function<void(M)> subscriber)
 	{
 		auto repo = m_repository.find(Message::id<M>());
-		bool valid = false;
-		std::size_t index = 0;
+		auto valid = false;
+		auto index = 0;
 
 		if (repo == m_repository.end())
 		{
@@ -47,7 +47,7 @@ namespace pub
 			index = static_cast<MessageContainer<M>*>(repo->second.get())->add(subscriber);
 		}
 
-		return SubscriberHandle(Message::id<M>(), index);
+        return SubscriberHandle{ Message::id<M>(), index };
 	}
 
 	template<typename M>
@@ -67,7 +67,9 @@ namespace pub
 		bool result = false;
 
 		if (handle.id() != Message::id<M>())
+        {
 			return result;
+        }
 
 		auto repo = m_repository.find(Message::id<M>());
 

--- a/include/PubBus/MessageBus.hpp
+++ b/include/PubBus/MessageBus.hpp
@@ -10,74 +10,74 @@
 
 namespace pub
 {
-	class MessageBus
-	{
-	public:
-		template<typename M>
-		SubscriberHandle subscribe(std::function<void(M)> subscriber);
-		template<typename M>
-		void publish(M message);
-		template<typename M>
-		bool validate(SubscriberHandle handle) const;
+    class MessageBus
+    {
+    public:
+        template<typename M>
+        SubscriberHandle subscribe(std::function<void(M)> subscriber);
+        template<typename M>
+        void publish(M message);
+        template<typename M>
+        bool validate(SubscriberHandle handle) const;
 
-	private:
-		std::map<Message::Id, std::unique_ptr<MessageContainerBase>> m_repository;
-	};
+    private:
+        std::map<Message::Id, std::unique_ptr<MessageContainerBase>> m_repository;
+    };
 
-	template<typename M>
-	SubscriberHandle MessageBus::subscribe(std::function<void(M)> subscriber)
-	{
-		auto repo = m_repository.find(Message::id<M>());
-		auto valid = false;
-		auto index = 0;
+    template<typename M>
+    SubscriberHandle MessageBus::subscribe(std::function<void(M)> subscriber)
+    {
+        auto repo = m_repository.find(Message::id<M>());
+        auto valid = false;
+        auto index = std::size_t{ 0u };
 
-		if (repo == m_repository.end())
-		{
-			auto result = m_repository.insert({ Message::id<M>(), std::make_unique<MessageContainer<M>>() });
-			valid = result.second;
-			repo = result.first;
-		}
-		else
-		{
-			valid = true;
-		}
-
-		if (valid)
-		{
-			index = static_cast<MessageContainer<M>*>(repo->second.get())->add(subscriber);
-		}
-
-        return SubscriberHandle{ Message::id<M>(), index };
-	}
-
-	template<typename M>
-	void MessageBus::publish(M message)
-	{
-		auto repo = m_repository.find(Message::id<M>());
-
-		if (repo != m_repository.end())
-		{
-			static_cast<MessageContainer<M>*>(repo->second.get())->publish(message);
-		}
-	}
-
-	template<typename M>
-	bool MessageBus::validate(SubscriberHandle handle) const
-	{
-		bool result = false;
-
-		if (handle.id() != Message::id<M>())
+        if (repo == m_repository.end())
         {
-			return result;
+            auto result = m_repository.insert({ Message::id<M>(), std::make_unique<MessageContainer<M>>() });
+            valid = result.second;
+            repo = result.first;
+        }
+        else
+        {
+            valid = true;
         }
 
-		auto repo = m_repository.find(Message::id<M>());
+        if (valid)
+        {
+            index = static_cast<MessageContainer<M>*>(repo->second.get())->add(subscriber);
+        }
 
-		if (repo != m_repository.end())
-		{
-			result = repo->second->validate(handle.index());
-		}
+        return SubscriberHandle{ Message::id<M>(), index };
+    }
 
-		return result;
-	}
+    template<typename M>
+    void MessageBus::publish(M message)
+    {
+        auto repo = m_repository.find(Message::id<M>());
+
+        if (repo != m_repository.end())
+        {
+            static_cast<MessageContainer<M>*>(repo->second.get())->publish(message);
+        }
+    }
+
+    template<typename M>
+    bool MessageBus::validate(SubscriberHandle handle) const
+    {
+        bool result = false;
+
+        if (handle.id() != Message::id<M>())
+        {
+            return result;
+        }
+
+        auto repo = m_repository.find(Message::id<M>());
+
+        if (repo != m_repository.end())
+        {
+            result = repo->second->validate(handle.index());
+        }
+
+        return result;
+    }
 }

--- a/include/PubBus/MessageContainer.hpp
+++ b/include/PubBus/MessageContainer.hpp
@@ -10,7 +10,7 @@ namespace pub
 	class MessageContainer : public MessageContainerBase
 	{
 	public:
-		~MessageContainer();
+		~MessageContainer() = default;
 
 		std::size_t size() const override final;
 		void remove(std::size_t index) override final;
@@ -24,11 +24,6 @@ namespace pub
 		std::map<std::size_t, std::function<void(M)>> m_subscribers;
 	};
 
-	template <typename M>
-	MessageContainer<M>::~MessageContainer()
-	{
-	}
-
 	template<typename M>
 	std::size_t MessageContainer<M>::size() const
 	{
@@ -38,11 +33,11 @@ namespace pub
 	template<typename M>
 	void MessageContainer<M>::remove(std::size_t index)
 	{
-		auto itr = m_subscribers.find(index);
+		auto iterator = m_subscribers.find(index);
 
-		if (itr != m_subscribers.end())
+		if (iterator != m_subscribers.end())
 		{
-			m_subscribers.erase(itr);
+			m_subscribers.erase(iterator);
 		}
 	}
 
@@ -63,7 +58,9 @@ namespace pub
 	template<typename M>
 	void MessageContainer<M>::publish(M message)
 	{
-		for (auto& subscriber : m_subscribers)
-			subscriber.second(message);
+        for (auto& subscriber : m_subscribers)
+        {
+            subscriber.second(message);
+        }
 	}
 }

--- a/include/PubBus/MessageContainer.hpp
+++ b/include/PubBus/MessageContainer.hpp
@@ -6,61 +6,61 @@
 
 namespace pub
 {
-	template<typename M>
-	class MessageContainer : public MessageContainerBase
-	{
-	public:
-		~MessageContainer() = default;
+    template<typename M>
+    class MessageContainer : public MessageContainerBase
+    {
+    public:
+        ~MessageContainer() = default;
 
-		std::size_t size() const override final;
-		void remove(std::size_t index) override final;
-		bool validate(std::size_t index) const override final;
+        std::size_t size() const override final;
+        void remove(std::size_t index) override final;
+        bool validate(std::size_t index) const override final;
 
-		std::size_t add(std::function<void(M)> subscriber);
-		void publish(M message);
+        std::size_t add(std::function<void(M)> subscriber);
+        void publish(M message);
 
-	private:
-		std::size_t m_index = 0;
-		std::map<std::size_t, std::function<void(M)>> m_subscribers;
-	};
+    private:
+        std::size_t m_index = 0;
+        std::map<std::size_t, std::function<void(M)>> m_subscribers;
+    };
 
-	template<typename M>
-	std::size_t MessageContainer<M>::size() const
-	{
-		return m_subscribers.size();
-	}
+    template<typename M>
+    std::size_t MessageContainer<M>::size() const
+    {
+        return m_subscribers.size();
+    }
 
-	template<typename M>
-	void MessageContainer<M>::remove(std::size_t index)
-	{
-		auto iterator = m_subscribers.find(index);
+    template<typename M>
+    void MessageContainer<M>::remove(std::size_t index)
+    {
+        auto iterator = m_subscribers.find(index);
 
-		if (iterator != m_subscribers.end())
-		{
-			m_subscribers.erase(iterator);
-		}
-	}
+        if (iterator != m_subscribers.end())
+        {
+            m_subscribers.erase(iterator);
+        }
+    }
 
-	template<typename M>
-	bool MessageContainer<M>::validate(std::size_t index) const
-	{
-		return m_subscribers.find(index) != m_subscribers.end();
-	}
+    template<typename M>
+    bool MessageContainer<M>::validate(std::size_t index) const
+    {
+        return m_subscribers.find(index) != m_subscribers.end();
+    }
 
-	template<typename M>
-	std::size_t MessageContainer<M>::add(std::function<void(M)> subscriber)
-	{
-		m_subscribers.insert({ m_index, subscriber });
-		++m_index;
-		return m_index - 1;
-	}
+    template<typename M>
+    std::size_t MessageContainer<M>::add(std::function<void(M)> subscriber)
+    {
+        m_subscribers.insert({ m_index, subscriber });
+        ++m_index;
+        return m_index - 1u;
+    }
 
-	template<typename M>
-	void MessageContainer<M>::publish(M message)
-	{
+    template<typename M>
+    void MessageContainer<M>::publish(M message)
+    {
         for (auto& subscriber : m_subscribers)
         {
             subscriber.second(message);
         }
-	}
+    }
 }

--- a/include/PubBus/MessageContainerBase.hpp
+++ b/include/PubBus/MessageContainerBase.hpp
@@ -4,12 +4,12 @@
 
 namespace pub
 {
-	class MessageContainerBase
-	{
-	public:
-		virtual ~MessageContainerBase() = default;
-		virtual std::size_t size() const = 0;
-		virtual void remove(std::size_t index) = 0;
-		virtual bool validate(std::size_t index) const = 0;
-	};
+    class MessageContainerBase
+    {
+    public:
+        virtual ~MessageContainerBase() = default;
+        virtual std::size_t size() const = 0;
+        virtual void remove(std::size_t index) = 0;
+        virtual bool validate(std::size_t index) const = 0;
+    };
 }

--- a/include/PubBus/MessageContainerBase.hpp
+++ b/include/PubBus/MessageContainerBase.hpp
@@ -7,14 +7,9 @@ namespace pub
 	class MessageContainerBase
 	{
 	public:
-		virtual ~MessageContainerBase();
+		virtual ~MessageContainerBase() = default;
 		virtual std::size_t size() const = 0;
 		virtual void remove(std::size_t index) = 0;
 		virtual bool validate(std::size_t index) const = 0;
 	};
-
-	inline MessageContainerBase::~MessageContainerBase()
-	{
-		
-	}
 }

--- a/include/PubBus/SubscriberHandle.hpp
+++ b/include/PubBus/SubscriberHandle.hpp
@@ -5,33 +5,33 @@
 
 namespace pub
 {
-	class SubscriberHandle
-	{
-	public:
-		SubscriberHandle(Message::Id id, std::size_t index);
+    class SubscriberHandle
+    {
+    public:
+        SubscriberHandle(Message::Id id, std::size_t index);
 
-		Message::Id id() const;
-		std::size_t index() const;
+        Message::Id id() const;
+        std::size_t index() const;
 
-	private:
-		Message::Id m_id;
-		std::size_t m_index;
-	};
+    private:
+        Message::Id m_id;
+        std::size_t m_index;
+    };
 
-	inline SubscriberHandle::SubscriberHandle(Message::Id id, std::size_t index)
-		: m_id(id)
-		, m_index(index)
-	{
+    inline SubscriberHandle::SubscriberHandle(Message::Id id, std::size_t index)
+        : m_id(id)
+        , m_index(index)
+    {
 
-	}
+    }
 
-	inline Message::Id SubscriberHandle::id() const
-	{
-		return m_id;
-	}
+    inline Message::Id SubscriberHandle::id() const
+    {
+        return m_id;
+    }
 
-	inline std::size_t SubscriberHandle::index() const
-	{
-		return m_index;
-	}
+    inline std::size_t SubscriberHandle::index() const
+    {
+        return m_index;
+    }
 }

--- a/test/MessageBusTest.cpp
+++ b/test/MessageBusTest.cpp
@@ -10,10 +10,10 @@ TEST_CASE("Adding subscriber returns a valid SubscriberHandle", "[MessageBus]")
 
 	};
 
-	pub::MessageBus bus;
+    auto bus = pub::MessageBus{};
 
 	// Act
-	pub::SubscriberHandle handle = bus.subscribe<DummyMessage>([](DummyMessage msg) {});
+	auto handle = bus.subscribe<DummyMessage>([](DummyMessage msg) {});
 
 	// Assert
 	REQUIRE(bus.validate<DummyMessage>(handle) == true);
@@ -32,11 +32,11 @@ TEST_CASE("Adding different message subscribers returns valid handles", "[Messag
 
 	};
 
-	pub::MessageBus bus;
+    auto bus = pub::MessageBus{};
 
 	// Act
-	pub::SubscriberHandle handle_one = bus.subscribe<DummyMessageOne>([](DummyMessageOne msg) {});
-	pub::SubscriberHandle handle_two = bus.subscribe<DummyMessageTwo>([](DummyMessageTwo msg) {});
+	auto handle_one = bus.subscribe<DummyMessageOne>([](DummyMessageOne msg) {});
+	auto handle_two = bus.subscribe<DummyMessageTwo>([](DummyMessageTwo msg) {});
 
 	// Assert
 	REQUIRE(bus.validate<DummyMessageOne>(handle_one) == true);
@@ -56,11 +56,11 @@ TEST_CASE("Validating subscribers for different messages returns false", "[Messa
 
 	};
 
-	pub::MessageBus bus;
+    auto bus = pub::MessageBus{};
 
 	// Act
-	pub::SubscriberHandle handle_one = bus.subscribe<DummyMessageOne>([](DummyMessageOne msg) {});
-	pub::SubscriberHandle handle_two = bus.subscribe<DummyMessageTwo>([](DummyMessageTwo msg) {});
+	auto handle_one = bus.subscribe<DummyMessageOne>([](DummyMessageOne msg) {});
+	auto handle_two = bus.subscribe<DummyMessageTwo>([](DummyMessageTwo msg) {});
 
 	// Assert
 	REQUIRE(bus.validate<DummyMessageOne>(handle_two) == false);
@@ -75,9 +75,9 @@ TEST_CASE("Publishing message calls subscriber", "[MessageBus]")
 
 	};
 
-	bool called = false;
-	pub::MessageBus bus;
-	DummyMessage msg;
+	auto called = false;
+    auto bus = pub::MessageBus{};
+    auto msg = DummyMessage{};
 
 	bus.subscribe<DummyMessage>([&called](DummyMessage msg) { called = true; });
 

--- a/test/MessageBusTest.cpp
+++ b/test/MessageBusTest.cpp
@@ -4,86 +4,86 @@
 
 TEST_CASE("Adding subscriber returns a valid SubscriberHandle", "[MessageBus]")
 {
-	// Arrange
-	class DummyMessage : public pub::Message
-	{
+    // Arrange
+    class DummyMessage : public pub::Message
+    {
 
-	};
+    };
 
     auto bus = pub::MessageBus{};
 
-	// Act
-	auto handle = bus.subscribe<DummyMessage>([](DummyMessage msg) {});
+    // Act
+    auto handle = bus.subscribe<DummyMessage>([](DummyMessage msg) {});
 
-	// Assert
-	REQUIRE(bus.validate<DummyMessage>(handle) == true);
+    // Assert
+    REQUIRE(bus.validate<DummyMessage>(handle) == true);
 }
 
 TEST_CASE("Adding different message subscribers returns valid handles", "[MessageBus]")
 {
-	// Arrange
-	class DummyMessageOne : public pub::Message
-	{
+    // Arrange
+    class DummyMessageOne : public pub::Message
+    {
 
-	};
+    };
 
-	class DummyMessageTwo : public pub::Message
-	{
+    class DummyMessageTwo : public pub::Message
+    {
 
-	};
+    };
 
     auto bus = pub::MessageBus{};
 
-	// Act
-	auto handle_one = bus.subscribe<DummyMessageOne>([](DummyMessageOne msg) {});
-	auto handle_two = bus.subscribe<DummyMessageTwo>([](DummyMessageTwo msg) {});
+    // Act
+    auto handle_one = bus.subscribe<DummyMessageOne>([](DummyMessageOne msg) {});
+    auto handle_two = bus.subscribe<DummyMessageTwo>([](DummyMessageTwo msg) {});
 
-	// Assert
-	REQUIRE(bus.validate<DummyMessageOne>(handle_one) == true);
-	REQUIRE(bus.validate<DummyMessageTwo>(handle_two) == true);
+    // Assert
+    REQUIRE(bus.validate<DummyMessageOne>(handle_one) == true);
+    REQUIRE(bus.validate<DummyMessageTwo>(handle_two) == true);
 }
 
 TEST_CASE("Validating subscribers for different messages returns false", "[MessageBus]")
 {
-	// Arrange
-	class DummyMessageOne : public pub::Message
-	{
+    // Arrange
+    class DummyMessageOne : public pub::Message
+    {
 
-	};
+    };
 
-	class DummyMessageTwo : public pub::Message
-	{
+    class DummyMessageTwo : public pub::Message
+    {
 
-	};
+    };
 
     auto bus = pub::MessageBus{};
 
-	// Act
-	auto handle_one = bus.subscribe<DummyMessageOne>([](DummyMessageOne msg) {});
-	auto handle_two = bus.subscribe<DummyMessageTwo>([](DummyMessageTwo msg) {});
+    // Act
+    auto handle_one = bus.subscribe<DummyMessageOne>([](DummyMessageOne msg) {});
+    auto handle_two = bus.subscribe<DummyMessageTwo>([](DummyMessageTwo msg) {});
 
-	// Assert
-	REQUIRE(bus.validate<DummyMessageOne>(handle_two) == false);
-	REQUIRE(bus.validate<DummyMessageTwo>(handle_one) == false);
+    // Assert
+    REQUIRE(bus.validate<DummyMessageOne>(handle_two) == false);
+    REQUIRE(bus.validate<DummyMessageTwo>(handle_one) == false);
 }
 
 TEST_CASE("Publishing message calls subscriber", "[MessageBus]")
 {
-	// Arrange
-	class DummyMessage : public pub::Message
-	{
+    // Arrange
+    class DummyMessage : public pub::Message
+    {
 
-	};
+    };
 
-	auto called = false;
+    auto called = false;
     auto bus = pub::MessageBus{};
     auto msg = DummyMessage{};
 
-	bus.subscribe<DummyMessage>([&called](DummyMessage msg) { called = true; });
+    bus.subscribe<DummyMessage>([&called](DummyMessage msg) { called = true; });
 
-	// Act
-	bus.publish(msg);
+    // Act
+    bus.publish(msg);
 
-	// Assert
-	REQUIRE(called == true);
+    // Assert
+    REQUIRE(called == true);
 }

--- a/test/MessageContainerTest.cpp
+++ b/test/MessageContainerTest.cpp
@@ -10,112 +10,112 @@ class DummyMessage : public pub::Message
 
 TEST_CASE("Empty container has a size of zero", "[MessageContainer]")
 {
-	// Arrange & Act
+    // Arrange & Act
     auto container = pub::MessageContainer<DummyMessage>{};
 
-	// Assert
-	REQUIRE(container.size() == 0);
+    // Assert
+    REQUIRE(container.size() == 0u);
 }
 
 TEST_CASE("Adding subscribers increases container size", "[MessageContainer]")
 {
-	// Arrange
+    // Arrange
     auto container = pub::MessageContainer<DummyMessage>{};
 
-	// Act
-	container.add([](DummyMessage){});
-	container.add([](DummyMessage){});
+    // Act
+    container.add([](DummyMessage){});
+    container.add([](DummyMessage){});
 
-	// Assert
-	REQUIRE(container.size() == 2);
+    // Assert
+    REQUIRE(container.size() == 2u);
 }
 
 TEST_CASE("Removing a non existing index does nothing", "[MessageContainer]")
 {
-	// Arrange
+    // Arrange
     auto container = pub::MessageContainer<DummyMessage>{};
 
-	// Act
-	container.remove(10);
+    // Act
+    container.remove(10);
 
-	// Assert
-	REQUIRE(container.size() == 0);
+    // Assert
+    REQUIRE(container.size() == 0u);
 }
 
 TEST_CASE("Removing an existing index decreases the size", "[MessageContainer]")
 {
-	// Arrange
+    // Arrange
     auto container = pub::MessageContainer<DummyMessage>{};
 
-	auto index_one = container.add([](DummyMessage){});
-	auto index_two = container.add([](DummyMessage) {});
+    auto index_one = container.add([](DummyMessage){});
+    auto index_two = container.add([](DummyMessage) {});
 
-	// Act
-	container.remove(index_one);
+    // Act
+    container.remove(index_one);
 
-	// Assert
-	REQUIRE(container.size() == 1);
+    // Assert
+    REQUIRE(container.size() == 1u);
 }
 
 TEST_CASE("Validating a non existing index returns false", "[MessageContainer]")
 {
-	// Arrange
+    // Arrange
     auto container = pub::MessageContainer<DummyMessage>{};
 
-	// Act
-	auto index = container.add([](DummyMessage) {});
+    // Act
+    auto index = container.add([](DummyMessage) {});
 
-	// Assert
-	REQUIRE(container.validate(index + 1) == false);
+    // Assert
+    REQUIRE(container.validate(index + 1u) == false);
 }
 
 TEST_CASE("Validating an existing index returns true", "[MessageContainer]")
 {
-	// Arrange
+    // Arrange
     auto container = pub::MessageContainer<DummyMessage>{};
 
-	// Act
-	auto index = container.add([](DummyMessage) {});
+    // Act
+    auto index = container.add([](DummyMessage) {});
 
-	// Assert
-	REQUIRE(container.validate(index) == true);
+    // Assert
+    REQUIRE(container.validate(index) == true);
 }
 
 TEST_CASE("Publishing a message calls the subscriber", "[MessageContainer]")
 {
-	// Arrange
-	auto called = false;
+    // Arrange
+    auto called = false;
     auto container = pub::MessageContainer<DummyMessage>{};
     auto msg = DummyMessage{};
 
-	container.add([&called](DummyMessage) { called = true; });
+    container.add([&called](DummyMessage) { called = true; });
 
-	// Act
-	container.publish(msg);
+    // Act
+    container.publish(msg);
 
-	// Assert
-	REQUIRE(called == true);
+    // Assert
+    REQUIRE(called == true);
 }
 
 TEST_CASE("A subscriber can access a published message", "[MessageContainer]")
 {
-	// Arrange
-	class DummyMessageInteractive : public pub::Message
-	{
-	public:
-		int test = 0;
-	};
+    // Arrange
+    class DummyMessageInteractive : public pub::Message
+    {
+    public:
+        int test = 0;
+    };
 
-	auto called = false;
+    auto called = false;
     auto container = pub::MessageContainer<DummyMessageInteractive>{};
     auto msg = DummyMessageInteractive{};
 
-	msg.test = 10;
-	container.add([&called](DummyMessageInteractive message) { called = (message.test == 10); });
+    msg.test = 10;
+    container.add([&called](DummyMessageInteractive message) { called = (message.test == 10); });
 
-	// Act
-	container.publish(msg);
+    // Act
+    container.publish(msg);
 
-	// Assert
-	REQUIRE(called == true);
+    // Assert
+    REQUIRE(called == true);
 }

--- a/test/MessageContainerTest.cpp
+++ b/test/MessageContainerTest.cpp
@@ -11,7 +11,7 @@ class DummyMessage : public pub::Message
 TEST_CASE("Empty container has a size of zero", "[MessageContainer]")
 {
 	// Arrange & Act
-	pub::MessageContainer<DummyMessage> container;
+    auto container = pub::MessageContainer<DummyMessage>{};
 
 	// Assert
 	REQUIRE(container.size() == 0);
@@ -20,7 +20,7 @@ TEST_CASE("Empty container has a size of zero", "[MessageContainer]")
 TEST_CASE("Adding subscribers increases container size", "[MessageContainer]")
 {
 	// Arrange
-	pub::MessageContainer<DummyMessage> container;
+    auto container = pub::MessageContainer<DummyMessage>{};
 
 	// Act
 	container.add([](DummyMessage){});
@@ -33,7 +33,7 @@ TEST_CASE("Adding subscribers increases container size", "[MessageContainer]")
 TEST_CASE("Removing a non existing index does nothing", "[MessageContainer]")
 {
 	// Arrange
-	pub::MessageContainer<DummyMessage> container;
+    auto container = pub::MessageContainer<DummyMessage>{};
 
 	// Act
 	container.remove(10);
@@ -45,13 +45,13 @@ TEST_CASE("Removing a non existing index does nothing", "[MessageContainer]")
 TEST_CASE("Removing an existing index decreases the size", "[MessageContainer]")
 {
 	// Arrange
-	pub::MessageContainer<DummyMessage> container;
+    auto container = pub::MessageContainer<DummyMessage>{};
 
-	std::size_t idx1 = container.add([](DummyMessage){});
-	std::size_t idx2 = container.add([](DummyMessage) {});
+	auto index_one = container.add([](DummyMessage){});
+	auto index_two = container.add([](DummyMessage) {});
 
 	// Act
-	container.remove(idx1);
+	container.remove(index_one);
 
 	// Assert
 	REQUIRE(container.size() == 1);
@@ -60,33 +60,34 @@ TEST_CASE("Removing an existing index decreases the size", "[MessageContainer]")
 TEST_CASE("Validating a non existing index returns false", "[MessageContainer]")
 {
 	// Arrange
-	pub::MessageContainer<DummyMessage> container;
+    auto container = pub::MessageContainer<DummyMessage>{};
 
 	// Act
-	std::size_t idx = container.add([](DummyMessage) {});
+	auto index = container.add([](DummyMessage) {});
 
 	// Assert
-	REQUIRE(container.validate(idx + 1) == false);
+	REQUIRE(container.validate(index + 1) == false);
 }
 
 TEST_CASE("Validating an existing index returns true", "[MessageContainer]")
 {
 	// Arrange
-	pub::MessageContainer<DummyMessage> container;
+    auto container = pub::MessageContainer<DummyMessage>{};
 
 	// Act
-	std::size_t idx = container.add([](DummyMessage) {});
+	auto index = container.add([](DummyMessage) {});
 
 	// Assert
-	REQUIRE(container.validate(idx) == true);
+	REQUIRE(container.validate(index) == true);
 }
 
 TEST_CASE("Publishing a message calls the subscriber", "[MessageContainer]")
 {
 	// Arrange
-	bool called = false;
-	pub::MessageContainer<DummyMessage> container;
-	DummyMessage msg;
+	auto called = false;
+    auto container = pub::MessageContainer<DummyMessage>{};
+    auto msg = DummyMessage{};
+
 	container.add([&called](DummyMessage) { called = true; });
 
 	// Act
@@ -105,9 +106,10 @@ TEST_CASE("A subscriber can access a published message", "[MessageContainer]")
 		int test = 0;
 	};
 
-	bool called = false;
-	pub::MessageContainer<DummyMessageInteractive> container;
-	DummyMessageInteractive msg;
+	auto called = false;
+    auto container = pub::MessageContainer<DummyMessageInteractive>{};
+    auto msg = DummyMessageInteractive{};
+
 	msg.test = 10;
 	container.add([&called](DummyMessageInteractive message) { called = (message.test == 10); });
 

--- a/test/MessageTest.cpp
+++ b/test/MessageTest.cpp
@@ -3,29 +3,29 @@
 
 TEST_CASE("Instances of the same Message type have the same ID", "[Message]")
 {
-	// Arrange
-	class DummyMessage : public pub::Message
-	{
+    // Arrange
+    class DummyMessage : public pub::Message
+    {
 
-	};
+    };
 
-	// Act & Assert
-	REQUIRE(pub::Message::id<DummyMessage>() == pub::Message::id<DummyMessage>());
+    // Act & Assert
+    REQUIRE(pub::Message::id<DummyMessage>() == pub::Message::id<DummyMessage>());
 }
 
 TEST_CASE("Instances of different Message types have different IDs", "[Message]")
 {
-	// Arrange
-	class DummyMessageOne : public pub::Message
-	{
+    // Arrange
+    class DummyMessageOne : public pub::Message
+    {
 
-	};
+    };
 
-	class DummyMessageTwo : public pub::Message
-	{
+    class DummyMessageTwo : public pub::Message
+    {
 
-	};
+    };
 
-	// Act & Assert
-	REQUIRE(pub::Message::id<DummyMessageOne>() != pub::Message::id<DummyMessageTwo>());
+    // Act & Assert
+    REQUIRE(pub::Message::id<DummyMessageOne>() != pub::Message::id<DummyMessageTwo>());
 }

--- a/test/SubscriberHandleTest.cpp
+++ b/test/SubscriberHandleTest.cpp
@@ -5,19 +5,19 @@
 
 TEST_CASE("Constructing a SubscriberHandle sets the index and id", "[SubscriberHandle]")
 {
-	// Arrange
-	class DummyMessage : public pub::Message
-	{
+    // Arrange
+    class DummyMessage : public pub::Message
+    {
 
-	};
+    };
 
-	auto id = pub::Message::id<DummyMessage>();
-	auto index = 10;
+    auto id = pub::Message::id<DummyMessage>();
+    auto index = 10u;
 
-	// Act
+    // Act
     auto handle = pub::SubscriberHandle{ id, index };
 
-	// Assert
-	REQUIRE(handle.id() == id);
-	REQUIRE(handle.index() == index);
+    // Assert
+    REQUIRE(handle.id() == id);
+    REQUIRE(handle.index() == index);
 }

--- a/test/SubscriberHandleTest.cpp
+++ b/test/SubscriberHandleTest.cpp
@@ -11,11 +11,11 @@ TEST_CASE("Constructing a SubscriberHandle sets the index and id", "[SubscriberH
 
 	};
 
-	pub::Message::Id id = pub::Message::id<DummyMessage>();
-	std::size_t index = 10;
+	auto id = pub::Message::id<DummyMessage>();
+	auto index = 10;
 
 	// Act
-	pub::SubscriberHandle handle(id, index);
+    auto handle = pub::SubscriberHandle{ id, index };
 
 	// Assert
 	REQUIRE(handle.id() == id);


### PR DESCRIPTION
- Enforce C++17 as language standard in VS
- Use almost always auto
- Rely on guaranteed copy elision