### PR TITLE
Use const references for message-passing

### DIFF
--- a/examples/Simple/Simple.cpp
+++ b/examples/Simple/Simple.cpp
@@ -12,7 +12,7 @@ int main()
     const auto message = DummyMessage{ .important_value = 100 };
 
     bus.subscribe<DummyMessage>(
-        [](const DummyMessage message)
+        [](const DummyMessage& message)
         {
             std::cout << "Important value: " << message.important_value << "\n";
         }

--- a/include/PubBus/MessageBus.hpp
+++ b/include/PubBus/MessageBus.hpp
@@ -14,10 +14,10 @@ namespace pub
     {
     public:
         template<typename M>
-        SubscriberHandle subscribe(std::function<void(M)> subscriber);
+        SubscriberHandle subscribe(std::function<void(const M&)> subscriber);
         void unsubscribe(SubscriberHandle& subscriber_handle);
         template<typename M>
-        void publish(M message);
+        void publish(const M& message);
         template<typename M>
         [[nodiscard]] bool validate(SubscriberHandle handle) const;
 
@@ -26,7 +26,7 @@ namespace pub
     };
 
     template<typename M>
-    SubscriberHandle MessageBus::subscribe(std::function<void(M)> subscriber)
+    SubscriberHandle MessageBus::subscribe(std::function<void(const M&)> subscriber)
     {
         auto repo = m_repository.find(Message::id<M>());
         auto valid = true;
@@ -58,7 +58,7 @@ namespace pub
     }
 
     template<typename M>
-    void MessageBus::publish(M message)
+    void MessageBus::publish(const M& message)
     {
         auto repo = m_repository.find(Message::id<M>());
 

--- a/include/PubBus/MessageContainer.hpp
+++ b/include/PubBus/MessageContainer.hpp
@@ -21,12 +21,12 @@ namespace pub
         void remove(std::size_t index) override final;
         [[nodiscard]] bool validate(std::size_t index) const override final;
 
-        std::size_t add(std::function<void(M)> subscriber);
-        void publish(M message);
+        std::size_t add(std::function<void(const M&)> subscriber);
+        void publish(const M& message);
 
     private:
         std::size_t m_index = 0;
-        std::map<std::size_t, std::function<void(M)>> m_subscribers;
+        std::map<std::size_t, std::function<void(const M&)>> m_subscribers;
     };
 
     template<typename M>
@@ -53,7 +53,7 @@ namespace pub
     }
 
     template<typename M>
-    std::size_t MessageContainer<M>::add(std::function<void(M)> subscriber)
+    std::size_t MessageContainer<M>::add(std::function<void(const M&)> subscriber)
     {
         m_subscribers.insert({ m_index, subscriber });
         ++m_index;
@@ -61,7 +61,7 @@ namespace pub
     }
 
     template<typename M>
-    void MessageContainer<M>::publish(M message)
+    void MessageContainer<M>::publish(const M& message)
     {
         for (auto& subscriber : m_subscribers)
         {


### PR DESCRIPTION
Basic optimization that pays off with larger messages.